### PR TITLE
Updating PHPstan to 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"minimum-stability": "dev",
 	"require": {
 		"php": "~7.1",
-		"phpstan/phpstan": "^0.10"
+		"phpstan/phpstan": "^0.11"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7.0"


### PR DESCRIPTION
Update PHPstan dependency to 0.11 (released at 19 jan 2019)