### PR TITLE
Group failures by file

### DIFF
--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -42,12 +42,8 @@ class JunitErrorFormatter implements ErrorFormatter
         $testsuite->setAttribute('failures', (string) $analysisResult->getTotalErrorsCount());
         $testsuites->appendChild($testsuite);
 
-        $returnCode = 1;
-
         if (!$analysisResult->hasErrors()) {
             $this->createTestCase($dom, $testsuite, 'phpstan', []);
-
-            $returnCode = 0;
         } else {
             /** @var array<string,array<int,\PHPStan\Analyser\Error>> $fileErrors */
             $fileErrors = [];
@@ -73,7 +69,7 @@ class JunitErrorFormatter implements ErrorFormatter
 
         $style->write($style->isDecorated() ? OutputFormatter::escape($dom->saveXML()) : $dom->saveXML());
 
-        return $returnCode;
+        return intval($analysisResult->hasErrors());
     }
 
     private function createTestCase(DOMDocument $dom, DOMElement $testsuite, string $reference, array $errors): void

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -36,17 +36,15 @@ class JunitErrorFormatter implements ErrorFormatter
         $testsuites->setAttribute('name', 'static analysis');
         $dom->appendChild($testsuites);
 
+        $testsuite = $dom->createElement('testsuite');
+        $testsuite->setAttribute('name', 'phpstan');
+        $testsuite->setAttribute('tests', (string) $analysisResult->getTotalErrorsCount());
+        $testsuite->setAttribute('failures', (string) $analysisResult->getTotalErrorsCount());
+        $testsuites->appendChild($testsuite);
+
         $returnCode = 1;
 
         if (!$analysisResult->hasErrors()) {
-            /** @var \DOMElement $testsuite */
-            $testsuite = $dom->createElement('testsuite');
-            $testsuite->setAttribute('name', 'phpstan');
-            $testsuite->setAttribute('tests', '1');
-            $testsuite->setAttribute('failures', '0');
-
-            $testsuites->appendChild($testsuite);
-
             $testcase = $dom->createElement('testcase');
             $testcase->setAttribute('name', 'phpstan');
             $testsuite->appendChild($testcase);
@@ -64,9 +62,6 @@ class JunitErrorFormatter implements ErrorFormatter
                 $fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
             }
 
-            /** @var \DOMElement $testsuite */
-            $testsuite = $testsuites->appendChild($dom->createElement('testsuite'));
-
             foreach ($fileErrors as $file => $errors) {
                 $this->createTestCase($dom, $testsuite, $this->relativePathHelper->getRelativePath($file), $errors);
             }
@@ -76,10 +71,6 @@ class JunitErrorFormatter implements ErrorFormatter
             if (count($genericErrors) > 0) {
                 $this->createTestCase($dom, $testsuite, 'Generic errors', $genericErrors);
             }
-
-            $testsuite->setAttribute('name', 'phpstan');
-            $testsuite->setAttribute('tests', (string) $analysisResult->getTotalErrorsCount());
-            $testsuite->setAttribute('failures', (string) $analysisResult->getTotalErrorsCount());
         }
 
         $style->write($style->isDecorated() ? OutputFormatter::escape($dom->saveXML()) : $dom->saveXML());

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -45,9 +45,7 @@ class JunitErrorFormatter implements ErrorFormatter
         $returnCode = 1;
 
         if (!$analysisResult->hasErrors()) {
-            $testcase = $dom->createElement('testcase');
-            $testcase->setAttribute('name', 'phpstan');
-            $testsuite->appendChild($testcase);
+            $this->createTestCase($dom, $testsuite, 'phpstan', []);
 
             $returnCode = 0;
         } else {

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -67,14 +67,10 @@ class JunitErrorFormatter implements ErrorFormatter
             /** @var \DOMElement $testsuite */
             $testsuite = $testsuites->appendChild($dom->createElement('testsuite'));
 
-            $totalErrors = 0;
-
             foreach ($fileErrors as $file => $errors) {
                 foreach ($errors as $error) {
                     $fileName = $this->relativePathHelper->getRelativePath($file);
                     $this->createTestCase($dom, $testsuite, sprintf('%s:%s', $fileName, (string) $error->getLine()), $error->getMessage());
-
-                    $totalErrors += 1;
                 }
             }
 
@@ -83,14 +79,12 @@ class JunitErrorFormatter implements ErrorFormatter
             if (count($genericErrors) > 0) {
                 foreach ($genericErrors as $genericError) {
                     $this->createTestCase($dom, $testsuite, 'Generic error', $genericError);
-
-                    $totalErrors += 1;
                 }
             }
 
             $testsuite->setAttribute('name', 'phpstan');
-            $testsuite->setAttribute('tests', (string) $totalErrors);
-            $testsuite->setAttribute('failures', (string) $totalErrors);
+            $testsuite->setAttribute('tests', (string) $analysisResult->getTotalErrorsCount());
+            $testsuite->setAttribute('failures', (string) $analysisResult->getTotalErrorsCount());
         }
 
         $style->write($style->isDecorated() ? OutputFormatter::escape($dom->saveXML()) : $dom->saveXML());

--- a/tests/JunitErrorFormatterTest.php
+++ b/tests/JunitErrorFormatterTest.php
@@ -25,8 +25,8 @@ class JunitErrorFormatterTest extends TestBaseFormatter
             0,
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="static analysis">
-  <testsuite failures="0" name="phpstan" tests="1">
-    <testcase name="phpstan"/>
+  <testsuite failures="0" name="phpstan" tests="0">
+    <testcase errors="0" failures="0" name="phpstan" tests="0"/>
   </testsuite>
 </testsuites>
 ',
@@ -40,8 +40,8 @@ class JunitErrorFormatterTest extends TestBaseFormatter
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="static analysis">
   <testsuite failures="1" name="phpstan" tests="1">
-    <testcase errors="0" failures="1" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4" tests="1">
-      <failure message="Foo" type="error" />
+    <testcase errors="0" failures="1" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php" tests="1">
+      <failure message="Line 4: Foo" type="error" />
     </testcase>
   </testsuite>
 </testsuites>
@@ -56,7 +56,7 @@ class JunitErrorFormatterTest extends TestBaseFormatter
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="static analysis">
   <testsuite failures="1" name="phpstan" tests="1">
-    <testcase errors="0" failures="1" name="Generic error" tests="1">
+    <testcase errors="0" failures="1" name="Generic errors" tests="1">
       <failure message="first generic error" type="error" />
     </testcase>
   </testsuite>
@@ -72,17 +72,13 @@ class JunitErrorFormatterTest extends TestBaseFormatter
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="static analysis">
   <testsuite failures="4" name="phpstan" tests="4">
-    <testcase errors="0" failures="1" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2" tests="1">
-      <failure message="Bar" type="error" />
+    <testcase errors="0" failures="2" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php" tests="2">
+      <failure message="Line 2: Bar" type="error" />
+      <failure message="Line 4: Foo" type="error" />
     </testcase>
-    <testcase errors="0" failures="1" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4" tests="1">
-      <failure message="Foo" type="error" />
-    </testcase>
-    <testcase errors="0" failures="1" name="foo.php:1" tests="1">
-      <failure message="Foo" type="error"/>
-    </testcase>
-    <testcase errors="0" failures="1" name="foo.php:5" tests="1">
-      <failure message="Bar" type="error"/>
+    <testcase errors="0" failures="2" name="foo.php" tests="2">
+      <failure message="Line 1: Foo" type="error"/>
+      <failure message="Line 5: Bar" type="error"/>
     </testcase>
   </testsuite>
 </testsuites>
@@ -97,10 +93,8 @@ class JunitErrorFormatterTest extends TestBaseFormatter
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="static analysis">
   <testsuite failures="2" name="phpstan" tests="2">
-    <testcase errors="0" failures="1" name="Generic error" tests="1">
+    <testcase errors="0" failures="2" name="Generic errors" tests="2">
       <failure message="first generic error" type="error" />
-    </testcase>
-    <testcase errors="0" failures="1" name="Generic error" tests="1">
       <failure message="second generic error" type="error"/>
     </testcase>
   </testsuite>
@@ -116,22 +110,16 @@ class JunitErrorFormatterTest extends TestBaseFormatter
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="static analysis">
   <testsuite failures="6" name="phpstan" tests="6">
-    <testcase errors="0" failures="1" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2" tests="1">
-      <failure message="Bar" type="error" />
+    <testcase errors="0" failures="2" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php" tests="2">
+      <failure message="Line 2: Bar" type="error" />
+      <failure message="Line 4: Foo" type="error" />
     </testcase>
-    <testcase errors="0" failures="1" name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4" tests="1">
-      <failure message="Foo" type="error" />
+    <testcase errors="0" failures="2" name="foo.php" tests="2">
+      <failure message="Line 1: Foo" type="error"/>
+      <failure message="Line 5: Bar" type="error"/>
     </testcase>
-    <testcase errors="0" failures="1" name="foo.php:1" tests="1">
-      <failure message="Foo" type="error"/>
-    </testcase>
-    <testcase errors="0" failures="1" name="foo.php:5" tests="1">
-      <failure message="Bar" type="error"/>
-    </testcase>
-    <testcase errors="0" failures="1" name="Generic error" tests="1">
+    <testcase errors="0" failures="2" name="Generic errors" tests="2">
       <failure message="first generic error" type="error" />
-    </testcase>
-    <testcase errors="0" failures="1" name="Generic error" tests="1">
       <failure message="second generic error" type="error"/>
     </testcase>
   </testsuite>


### PR DESCRIPTION
Since the code suggests an intent to group the errors by file (with the creation of the `$fileErrors` array) but doesn't achieve this intent, let's do it !

I did some refactoring too and committed atomically so you can follow each step easily.

PHPStan, PHPCS and PHPUnit tests are passing.

I use Gitmoji if you ask (see https://gitmoji.carloscuesta.me/).

My CI platform thank you for your contribution ! Keep up the good work !