### PR TITLE
refs #36: Stop to distribute unuseful file via packagist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
+/.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore
 /phpcs.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore
+/tests-integration export-ignore


### PR DESCRIPTION
Closes #36

### Relevant commits/breaking changes

  - Stop to distribute unuseful file via packagist