### PR TITLE
Update phpstan-junit to support PHP 8, phpunit 9

### DIFF
--- a/.github/workflows/push-coding_standard.yml
+++ b/.github/workflows/push-coding_standard.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
     - name: Checkout

--- a/.github/workflows/push-coding_standard.yml
+++ b/.github/workflows/push-coding_standard.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring
+        extensions: mbstring
 
     - name: Get composer cache directory
       id: composer-cache

--- a/.github/workflows/push-coding_standard.yml
+++ b/.github/workflows/push-coding_standard.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer install --no-progress --no-suggest --prefer-dist
+        composer update --no-progress --prefer-dist
 
     - name: Run Coding standard
       run: |

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
     - name: Checkout

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -20,10 +20,10 @@ jobs:
         args: -c "go get github.com/drone/envsubst/cmd/envsubst; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring
+        extensions: mbstring
 
     - name: Get composer cache directory
       id: composer-cache

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: prepare
-      uses: docker://golang
+      uses: docker://ubuntu:latest
       with:
         entrypoint: sh
-        args: -c "go get github.com/a8m/envsubst/cmd/envsubst; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
+        args: -c "apt update; apt install gettext-base; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: prepare
-      uses: docker://ubuntu:latest
+      uses: docker://ubuntu:rolling
       with:
         entrypoint: sh
         args: -c "apt update; apt install gettext-base; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: prepare
-      uses: docker://ubuntu:latest
+      uses: docker://golang
       with:
         entrypoint: sh
-        args: -c "apt update; apt install gettext-base; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
+        args: -c "pushd ~; git clone https://github.com/drone/envsubst.git; pushd envsubst/cmd/envsubst; go build; go install; popd; popd; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer install --working-dir tests-integration --no-progress --no-suggest --prefer-dist
+        composer update --working-dir tests-integration --no-progress --prefer-dist
 
     - name: Execute integration test
       run: |

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: prepare
-      uses: docker://ubuntu:rolling
+      uses: docker://ubuntu:latest
       with:
         entrypoint: sh
         args: -c "apt update; apt install gettext-base; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: prepare
       uses: docker://golang
       with:
-        entrypoint: sh
+        entrypoint: bash
         args: -c "pushd ~; git clone https://github.com/drone/envsubst.git; pushd envsubst/cmd/envsubst; go build; go install; popd; popd; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
 
     - name: Setup PHP

--- a/.github/workflows/push-integration-test.yml
+++ b/.github/workflows/push-integration-test.yml
@@ -17,7 +17,7 @@ jobs:
       uses: docker://golang
       with:
         entrypoint: sh
-        args: -c "go get github.com/drone/envsubst/cmd/envsubst; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
+        args: -c "go get github.com/a8m/envsubst/cmd/envsubst; envsubst < ${GITHUB_WORKSPACE}/tests-integration/composer.json.dist > ${GITHUB_WORKSPACE}/tests-integration/composer.json"
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php

--- a/.github/workflows/push-static_analysis.yml
+++ b/.github/workflows/push-static_analysis.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
     - name: Checkout

--- a/.github/workflows/push-static_analysis.yml
+++ b/.github/workflows/push-static_analysis.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring
+        extensions: mbstring
 
     - name: Get composer cache directory
       id: composer-cache

--- a/.github/workflows/push-static_analysis.yml
+++ b/.github/workflows/push-static_analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer install --no-progress --no-suggest --prefer-dist
+        composer update --no-progress --prefer-dist
 
     - name: Run Coding standard
       run: |

--- a/.github/workflows/push-testing.yml
+++ b/.github/workflows/push-testing.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
     - name: Checkout

--- a/.github/workflows/push-testing.yml
+++ b/.github/workflows/push-testing.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer install --no-progress --no-suggest --prefer-dist
+        composer update --no-progress --prefer-dist
 
     - name: Run Tests
       run: |

--- a/.github/workflows/push-testing.yml
+++ b/.github/workflows/push-testing.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v1 #https://github.com/shivammathur/setup-php
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
       with:
         php-version: ${{ matrix.php-versions }}
-        extension-csv: mbstring
+        extensions: mbstring
         coverage: xdebug #optional
 
     - name: Get composer cache directory

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     },
     "require": {
-        "php": "~7.1",
         "phpstan/phpstan": "^0.12"
+        "php": ">=7.1",
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12-dev",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mavimo/phpstan-junit",
+    "name": "magikid/phpstan-junit",
     "description": "PHPStan JUnit error reporter",
     "type": "phpstan-extension",
     "license": [
@@ -9,6 +9,10 @@
         {
             "name": "Marco Vito Moscaritolo",
             "email": "mavimo@gmail.com"
+        },
+        {
+            "name": "Chris W Jones",
+            "email": "chris@christopherjones.us"
         }
     ],
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
         }
     },
     "require": {
-        "phpstan/phpstan": "^0.12"
         "php": ">=7.1",
+        "phpstan/phpstan": "^0.12",
+        "ext-dom": "*"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12-dev",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12-dev",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "slevomat/coding-standard": "^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12-dev",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.0",
         "slevomat/coding-standard": "^6.0"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,6 +17,7 @@
 
     <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
             <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
+            <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
             <exclude name="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses"/>
             <exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison"/>
             <exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,40 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         bootstrap="./vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="phpstan-junit">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-clover" target="clover-report.xml" />
-    </logging>
-
-    <php>
-        <ini name="display_errors" value="On"/>
-        <ini name="memory_limit" value="-1"/>
-        <ini name="max_execution_time" value="0"/>
-        <ini name="display_startup_errors" value="On"/>
-        <ini name="error_reporting" value="E_ALL"/>
-        <ini name="date.timezone" value="UTC"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" failOnRisky="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="clover-report.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="phpstan-junit">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <php>
+    <ini name="display_errors" value="On"/>
+    <ini name="memory_limit" value="-1"/>
+    <ini name="max_execution_time" value="0"/>
+    <ini name="display_startup_errors" value="On"/>
+    <ini name="error_reporting" value="E_ALL"/>
+    <ini name="date.timezone" value="UTC"/>
+  </php>
 </phpunit>

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -81,7 +81,12 @@ class JunitErrorFormatter implements ErrorFormatter
 
         if ($message !== null) {
             $failure = $dom->createElement('failure');
-            $failure->setAttribute('message', $message);
+            $newMessage = explode("\n", $message);
+            if ($newMessage === false) {
+                $newMessage = [$message];
+            }
+
+            $failure->setAttribute('message', $newMessage[0]);
 
             $testcase->appendChild($failure);
         }

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -82,6 +82,7 @@ class JunitErrorFormatter implements ErrorFormatter
         if ($message !== null) {
             $failure = $dom->createElement('failure');
             $newMessage = explode("\n", $message);
+
             if ($newMessage === false) {
                 $newMessage = [$message];
             }

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -52,7 +52,7 @@ class JunitErrorFormatter implements ErrorFormatter
             $this->createTestCase($dom, $testsuite, 'phpstan');
         }
 
-        $output->writeRaw($dom->saveXML());
+        $output->writeRaw($dom->saveXML() ?: '');
 
         return intval($analysisResult->hasErrors());
     }

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -81,7 +81,7 @@ class JunitErrorFormatter implements ErrorFormatter
 
         if ($message !== null) {
             $failure = $dom->createElement('failure');
-            /** @var false|string[] $newMessage */
+            /** @var false|array<string> $newMessage */
             $newMessage = explode("\n", $message);
 
             if ($newMessage === false || count($newMessage) === 0) {

--- a/src/JunitErrorFormatter.php
+++ b/src/JunitErrorFormatter.php
@@ -64,7 +64,7 @@ class JunitErrorFormatter implements ErrorFormatter
         if ($xmlOutput === false) {
             $output->writeRaw('');
         } else {
-            $output->writeRaw($dom->saveXML());
+            $output->writeRaw($xmlOutput);
         }
 
         return intval($analysisResult->hasErrors());
@@ -81,9 +81,10 @@ class JunitErrorFormatter implements ErrorFormatter
 
         if ($message !== null) {
             $failure = $dom->createElement('failure');
+            /** @var false|string[] $newMessage */
             $newMessage = explode("\n", $message);
 
-            if ($newMessage === false) {
+            if ($newMessage === false || count($newMessage) === 0) {
                 $newMessage = [$message];
             }
 

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -1,16 +1,19 @@
 {
-    "name": "mavimo/phpstan-junit-tests-integration",
+    "name": "magikid/phpstan-junit-tests-integration",
     "authors": [
         {
             "name": "Marco Vito Moscaritolo",
             "email": "mavimo@gmail.com"
+        },
+        {
+            "name": "Chris W Jones",
+            "email": "chris@christopherjones.us"
         }
     ],
     "repositories": [
         {
             "type": "vcs",
             "url": "../",
-            "canonical": false
         }
     ],
     "minimum-stability": "dev",
@@ -18,6 +21,6 @@
     "require-dev": {
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
-        "mavimo/phpstan-junit": "dev-${GITHUB_REF#refs/heads/}#${GITHUB_SHA}"
+        "magikid/phpstan-junit": "dev-${GITHUB_REF#refs/heads/}#${GITHUB_SHA}"
     }
 }

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -6,6 +6,12 @@
             "email": "mavimo@gmail.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "../"
+        }
+    ],
     "minimum-stability": "dev",
     "require": {},
     "require-dev": {

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -11,6 +11,6 @@
     "require-dev": {
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
-        "mavimo/phpstan-junit": "dev-master#${GITHUB_SHA}"
+        "mavimo/phpstan-junit": "dev-${GITHUB_REF#refs/heads/}#${GITHUB_SHA}"
     }
 }

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -17,6 +17,6 @@
     "require-dev": {
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
-        "mavimo/phpstan-junit": "dev-master#${GITHUB_SHA}"
+        "mavimo/phpstan-junit": "dev-master#${GITHUB_SHA} as 1.0"
     }
 }

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -6,17 +6,11 @@
             "email": "mavimo@gmail.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "../"
-        }
-    ],
     "minimum-stability": "dev",
     "require": {},
     "require-dev": {
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
-        "mavimo/phpstan-junit": "dev-master#${GITHUB_SHA} as 1.0"
+        "mavimo/phpstan-junit": "dev-master#${GITHUB_SHA}"
     }
 }

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -17,6 +17,6 @@
     "require-dev": {
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
-        "mavimo/phpstan-junit": "dev-${GITHUB_REF#refs/heads/}#${GITHUB_SHA}"
+        "mavimo/phpstan-junit": "dev-master#${GITHUB_SHA}"
     }
 }

--- a/tests-integration/composer.json.dist
+++ b/tests-integration/composer.json.dist
@@ -9,7 +9,8 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "../"
+            "url": "../",
+            "canonical": false
         }
     ],
     "minimum-stability": "dev",

--- a/tests/JunitErrorFormatterTest.php
+++ b/tests/JunitErrorFormatterTest.php
@@ -62,7 +62,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             0,
             1,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation=
     "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="Generic error">
@@ -77,7 +77,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             4,
             0,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="4" name="phpstan" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<testsuite failures="4" name="phpstan" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation=
     "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
@@ -101,7 +101,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             0,
             2,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="2" name="phpstan" tests="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<testsuite failures="2" name="phpstan" tests="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation=
     "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="Generic error">
@@ -119,7 +119,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             4,
             2,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="6" name="phpstan" tests="6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<testsuite failures="6" name="phpstan" tests="6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation=
     "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">

--- a/tests/JunitErrorFormatterTest.php
+++ b/tests/JunitErrorFormatterTest.php
@@ -34,7 +34,9 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             0,
             0,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="0" name="phpstan" tests="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="0" name="phpstan" tests="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation=
+    "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="phpstan"/>
 </testsuite>
 ',
@@ -45,7 +47,9 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             1,
             0,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation=
+    "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4">
     <failure message="Foo" />
   </testcase>
@@ -58,7 +62,9 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             0,
             1,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation=
+    "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="Generic error">
     <failure message="first generic error" />
   </testcase>
@@ -71,7 +77,9 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             4,
             0,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="4" name="phpstan" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="4" name="phpstan" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation=
+    "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
     <failure message="Bar" />
   </testcase>
@@ -93,7 +101,9 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             0,
             2,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="2" name="phpstan" tests="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="2" name="phpstan" tests="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation=
+    "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="Generic error">
     <failure message="first generic error" />
   </testcase>
@@ -109,7 +119,9 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
             4,
             2,
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="6" name="phpstan" tests="6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="6" name="phpstan" tests="6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation=
+    "https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
     <failure message="Bar" />
   </testcase>
@@ -138,12 +150,8 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
      *
      * @dataProvider dataFormatterOutputProvider
      */
-    public function testFormatErrors(
-        int $exitCode,
-        int $numFileErrors,
-        int $numGenericErrors,
-        string $expected
-    ): void {
+    public function testFormatErrors(int $exitCode, int $numFileErrors, int $numGenericErrors, string $expected): void
+    {
         $this->assertSame(
             $exitCode,
             $this->formatter->formatErrors(
@@ -157,7 +165,10 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
         $xml->loadXML($this->getOutputContent());
 
         $this->assertTrue(
-            $xml->schemaValidate('https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd'),
+            $xml->schemaValidate(
+                'https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/'.
+                'jenkins-junit.xsd'
+            ),
             'Schema do not validate'
         );
 


### PR DESCRIPTION
Refs #53 

This PR is to update this library to support PHP 8.  There were lots of little changes required.

- Updates `JunitErrorFormatter#createTestCase` to truncate after line breaks as that is what the test expects
- Adds PHP 8 to tested versions, updates composer.json to allow it
- Updates the `setup-php` container to v2
- Change the envsubst library to use https://github.com/a8m/envsubst/cmd/envsubst
- Fix many issue with the style of the code

The only test that still fails is the `tests-functional` and that is due to the `mavimo/phpstan-junit` repo not having the changes in composer.json that allow PHP 8.